### PR TITLE
Mfw 248 route table api

### DIFF
--- a/plugins/stats/pinger.go
+++ b/plugins/stats/pinger.go
@@ -239,7 +239,7 @@ func watchNetworkSocket(socket *pingSocket) {
 		// make sure the ID in the reply matches our PID from the request
 		answer := reply.Body.(*icmp.Echo)
 		if answer.ID != masterPid {
-			logger.Warn("Unexpected message ID - received:%d expecting:%d", answer.ID, masterPid)
+			logger.Warn("Unexpected message ID - received:%d expecting:%d\n", answer.ID, masterPid)
 			continue
 		}
 

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -106,6 +106,9 @@ func Startup() {
 	api.GET("/status/arp/", statusArp)
 	api.GET("/status/arp/:device", statusArp)
 	api.GET("/status/dhcp", statusDHCP)
+	api.GET("/status/route", statusRoute)
+	api.GET("/status/route/:table", statusRoute)
+	api.GET("/status/rules", statusRules)
 
 	api.GET("/debug", debugHandler)
 	api.POST("/gc", gcHandler)

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -110,6 +110,7 @@ func Startup() {
 	api.GET("/status/routetables", statusRouteTables)
 	api.GET("/status/route/:table", statusRoute)
 	api.GET("/status/rules", statusRules)
+	api.GET("/status/routerules", statusRouteRules)
 
 	api.GET("/debug", debugHandler)
 	api.POST("/gc", gcHandler)

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -107,6 +107,7 @@ func Startup() {
 	api.GET("/status/arp/:device", statusArp)
 	api.GET("/status/dhcp", statusDHCP)
 	api.GET("/status/route", statusRoute)
+	api.GET("/status/routetables", statusRouteTables)
 	api.GET("/status/route/:table", statusRoute)
 	api.GET("/status/rules", statusRules)
 

--- a/services/restd/status.go
+++ b/services/restd/status.go
@@ -280,6 +280,7 @@ func statusRouteTables(c *gin.Context) {
 	}
 
 	//append awk results to rtTables
+	logger.Info("Result parse: %v", result)
 
 	c.JSON(http.StatusOK, rtTables)
 	return

--- a/services/restd/status.go
+++ b/services/restd/status.go
@@ -270,7 +270,19 @@ func statusRules(c *gin.Context) {
 
 // statusRouteTables returns routing table names to pass into the statusRoute api
 func statusRouteTables(c *gin.Context) {
+	rtTables := []string{"main", "balance", "default", "local", "220"}
 
+	//read through rt_tables and append
+	result, err := exec.Command("awk", "/wan/ {print $2}", "/etc/iproute2/rt_tables").CombinedOutput()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	//append awk results to rtTables
+
+	c.JSON(http.StatusOK, rtTables)
+	return
 }
 
 type interfaceInfo struct {

--- a/services/restd/status.go
+++ b/services/restd/status.go
@@ -313,11 +313,11 @@ type interfaceInfo struct {
 }
 
 type dhcpInfo struct {
-	LeaseExpiration uint   `json:leaseExpiration`
-	MACAddress      string `json:macAddress`
-	IPAddr          string `json:ipAddr`
-	Hostname        string `json:hostName`
-	ClientID        string `json:clientId`
+	LeaseExpiration uint   `json:"leaseExpiration"`
+	MACAddress      string `json:"macAddress"`
+	IPAddr          string `json:"ipAddr"`
+	Hostname        string `json:"hostName"`
+	ClientID        string `json:"clientId"`
 }
 
 // getInterfaceInfo returns a json object with details for the requested interface


### PR DESCRIPTION
I added multiple commands to expose most of the logic done in the NGFW script (ut-routedump.sh)

The equivalents from the script are detailed here: 

https://{{server}}/api/status/rules
	ip -4 rule ls
	ip -6 rule ls

https://{{server}}/api/status/route/{tablename}
	ip -4 route show table $i (main balance default local)
	ip -4 route show table $table (rt_tables parse)
        ip -6 route show table $i (main, default, local)
        ip -6 route show table $table (rt_tables parse)
	ip route show table 220

https://{{server}}/api/status/routetables
	for i in main balance default local ; do
	for i in main default local ; do
	awk '/wan/ {print $2}' /etc/iproute2/rt_tables | while read table ; do
	awk '/wan/ {print $2}' /etc/iproute2/rt_tables | while read table ; do

(TBD)
ip -4 route show proto zebra

https://{{server}}/api/status/routerules
        iptables -t mangle -nL wan-balancer-route-rules 2>/dev/null | grep -v -E '(Chain|target)'
        nft list chain inet table wan-routing user-wan-rules



I also modified some of the IP XXX commands to utilize the json flag exposed in iproute2, and did a few other QOL changes (adding \n to a log line, fixing json serialization on dhcp API)

