### PR TITLE
Fix database to eliminate locked condition

### DIFF
--- a/cmd/packetd/packetd.go
+++ b/cmd/packetd/packetd.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -496,8 +495,6 @@ func printStats() {
 	logger.Info("Memory TotalAlloc: %d kB\n", (mem.TotalAlloc / 1024))
 	logger.Info("Memory HeapAlloc: %d kB\n", (mem.HeapAlloc / 1024))
 	logger.Info("Memory HeapSys: %d kB\n", (mem.HeapSys / 1024))
-
-	logger.Info("Reports EventsLogged: %d\n", atomic.LoadUint64(&reports.EventsLogged))
 	stats, err := getProcStats()
 	if err == nil {
 		for _, line := range strings.Split(stats, "\n") {

--- a/services/reports/sql.go
+++ b/services/reports/sql.go
@@ -10,7 +10,6 @@ import (
 )
 
 // makeSQLString makes a SQL string from a ReportEntry
-// You must hold the dbLock read lock to call this function
 func makeSQLString(reportEntry *ReportEntry) (string, error) {
 	if reportEntry.Table == "" {
 		return "", errors.New("Missing required attribute Table")
@@ -304,11 +303,14 @@ func getDistinctValues(reportEntry *ReportEntry) ([]string, error) {
 		logger.Warn("Failed to get Distinct values: %v\n", err)
 		return nil, err
 	}
+
+	// rows is valid so make sure it gets closed
+	defer rows.Close()
+
 	categories, err := getRows(rows, reportEntry.QueryCategories.Limit)
 	if err != nil {
 		return nil, err
 	}
-	rows.Close()
 
 	var values []string
 


### PR DESCRIPTION
An online thread suggested the "database is busy" message can be caused
by not properly closing database resources. I fixed three places where
a sql.Rows or sql.Stmt object might not have been closed if an error
occurred while processing the database result. I strongly suspect one of
these edge cases is the root cause of the issue initially observed and
reported by QA. In the process of tracking down and solving this issue
I made some additional improvements. First, I removed the external
RWLock mutex protecting the dbMain object since it should not be
required, as the database package and driver handle locking and
synchronization internally. I then set a busy timeout on our database
connection to allow the driver to retry when there is contention.
I also removed the database vacuum operation since it likely isn't
beneficial in our environment. The database is now allowed to grow
to 40% of the space available in /tmp at which point we'll start
trimming older data when there is less than 32k worth of free page
space available for new data. To improve performance, I turned off
the driver synchronous mode which was forcing a disk sync after every
write operation, and I set the rollback journal to be memory based.
I updated the runSQL function to return a string since we need the
result from some commands such as querying the page size details.