### PR TITLE
Add persistent connections and goroutine pool for prediction

### DIFF
--- a/services/predicttrafficsvc/predicttrafficsvc.go
+++ b/services/predicttrafficsvc/predicttrafficsvc.go
@@ -499,5 +499,5 @@ func sessionKeepalive(conn *tls.Conn, buffer []byte) {
 		break
 	}
 
-	logger.Info("Received %d keepAlive bytes from server...\n%s\n", count, reply)
+	logger.Trace("Received %d keepAlive bytes from server...\n%s\n", count, reply)
 }

--- a/services/predicttrafficsvc/predicttrafficsvc.go
+++ b/services/predicttrafficsvc/predicttrafficsvc.go
@@ -302,7 +302,7 @@ func lookupWorker(index int) {
 		case <-shutdownChannel:
 			goodbye = true
 		case <-time.After(cloudAPIKeepalive * time.Second):
-			logger.Info("Lookup worker %d sending keep-alive message\n", index)
+			logger.Debug("%OC|Lookup worker %d sending keep-alive message\n", "predict_server_keepalive", 0, index)
 			sessionKeepalive(conn, buffer)
 		}
 	}


### PR DESCRIPTION
I was seeing quite a few timeouts on live devices when the prediction
service was querying the cloud API, likely rooted deep in the
complexities of the golang http package. Since we're calling the
API for traffic in real time, I wanted to make the lookup as fast and
efficient as possible. My solution was to create a pool of worker
goroutines, each with a persistent connection to the cloud API.
Each worker reads requests from a shared channel, does a lookup using
it's own persisent connection, and returns the result to the caller
using a dedicated result channel. Since the API protocol is fairly
simple, I opted to use the lower level crypto/tls package for the
network connections, while directly managing the request and reply
messages. This avoids all of the complexities with buffered readers
and other cruft in the general purpose network packages.