### PR TITLE
Modify predict service to use persistent transport and client

### DIFF
--- a/services/predicttrafficsvc/predicttrafficsvc.go
+++ b/services/predicttrafficsvc/predicttrafficsvc.go
@@ -76,7 +76,7 @@ func Startup() {
 		MaxIdleConnsPerHost:   runtime.NumCPU(),
 		IdleConnTimeout:       300 * time.Second,
 		TLSHandshakeTimeout:   5 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		ExpectContinueTimeout: 0,
 	}
 
 	client = &http.Client{
@@ -140,6 +140,7 @@ func sendClassifyRequest(ipAdd net.IP, port uint16, protoID uint8) *ClassifiedTr
 	req, err := http.NewRequest("GET", requestURL, nil)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("AuthRequest", authRequestKey)
+	req.Header.Add("Connection", "Keep-Alive")
 
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
The existing logic is right on the money. We just needed to move
the creation of the http transport and client objects into the
startup function so they can persist and be shared, and tweak the
timeout and idle connection limits to complement our use case.
According to the golang net/http docs, Clients and Transports are
safe for concurrent use by multiple goroutines and for efficiency
should only be created once and re-used.