### PR TITLE
Add ordering query options for EVENTS reports

### DIFF
--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -65,6 +65,12 @@ type QuerySeriesOptions struct {
 	TimeIntervalSeconds int      `json:"timeIntervalSeconds"`
 }
 
+// QueryEventsOptions stores the query options for EVENTS type reports
+type QueryEventsOptions struct {
+	OrderByColumn string `json:"orderByColumn"`
+	OrderAsc      bool   `json:"orderAsc"`
+}
+
 // ReportCondition holds a SQL reporting condition (ie client = 1.2.3.4)
 type ReportCondition struct {
 	Column   string      `json:"column"`
@@ -94,6 +100,7 @@ type ReportEntry struct {
 	QueryCategories      QueryCategoriesOptions       `json:"queryCategories"`
 	QueryText            QueryTextOptions             `json:"queryText"`
 	QuerySeries          QuerySeriesOptions           `json:"querySeries"`
+	QueryEvents          QueryEventsOptions           `json:"queryEvents"`
 }
 
 var dbMain *sql.DB

--- a/services/reports/sql.go
+++ b/services/reports/sql.go
@@ -67,6 +67,15 @@ func makeTextSQLString(reportEntry *ReportEntry) (string, error) {
 
 // makeEventsSQLString makes a SQL string from a EVENTS type ReportEntry
 func makeEventsSQLString(reportEntry *ReportEntry) (string, error) {
+	var orderByColumn = "time_stamp"
+	var order = "DESC"
+	if reportEntry.QueryEvents.OrderByColumn != "" {
+		orderByColumn = reportEntry.QueryEvents.OrderByColumn
+	}
+	if reportEntry.QueryEvents.OrderAsc {
+		order = "ASC"
+	}
+
 	sqlStr := "SELECT * FROM"
 	sqlStr += " " + escape(reportEntry.Table)
 	sqlStr += " WHERE"
@@ -81,6 +90,10 @@ func makeEventsSQLString(reportEntry *ReportEntry) (string, error) {
 		}
 		sqlStr += newStr
 	}
+
+	sqlStr += fmt.Sprintf(" ORDER BY %s %s", orderByColumn, order)
+
+	logger.Debug("Events SQL: %v %v\n", sqlStr)
 	return sqlStr, nil
 }
 


### PR DESCRIPTION
MFW-792

Because the large amount of session events, and the limitation to fetch max 3000,
order events by time_stamp descending, by default.

This avoids missing latest records for EVENTS type reports.