### PR TITLE
MFW-810 database enhancements

### DIFF
--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -201,7 +201,9 @@ func customHook(conn *sqlite3.SQLiteConn) error {
 		logger.Warn("Error setting busy_timeout: %v\n", err)
 	}
 
-	// enable auto vaccuum = FULL
+	// enable auto vaccuum = FULL, this will clean up empty pages by moving them
+	// to the end of the DB file. This will reclaim data from data that has been
+	// removed from the database.
 	if _, err := conn.Exec("PRAGMA auto_vacuum = FULL", nil); err != nil {
 		logger.Warn("Error setting auto_vacuum: %v\n", err)
 	}
@@ -985,7 +987,7 @@ func dbCleaner() {
 // loadDbStats gets the page size, page count, free list size, and current DB size from the database
 // returns currentSize (int64) - The DB Size in bytes
 // returns pageSize (int64) - The current page size of each DB page
-// returns pageCount (int64) - The current number of pages in the database 
+// returns pageCount (int64) - The current number of pages in the database
 // returns maxPageCount (int64) - The maximum number of pages the database can hold
 // returns freeCount (int64) - The number of free pages in the DB file
 func loadDbStats() (currentSize int64, pageSize int64, pageCount int64, maxPageCount int64, freeCount int64) {

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -243,7 +243,7 @@ func CreateQuery(reportEntryStr string) (*Query, error) {
 	var rows *sql.Rows
 	var sqlStmt *sql.Stmt
 
-	sqlStmt, err = getPreparedStatement(reportEntry, dbMain)
+	sqlStmt, err = getPreparedStatement(reportEntry)
 	if err != nil {
 		logger.Warn("Failed to get prepared SQL: %v\n", err)
 		return nil, err
@@ -278,7 +278,7 @@ func CreateQuery(reportEntryStr string) (*Query, error) {
 // this largely takes from the ideas here: https://thenotexpert.com/golang-sql-recipe/
 //
 //
-func getPreparedStatement(reportEntry *ReportEntry, db *sql.DB) (*sql.Stmt, error) {
+func getPreparedStatement(reportEntry *ReportEntry) (*sql.Stmt, error) {
 
 	var stmt *sql.Stmt
 	var present bool
@@ -307,7 +307,7 @@ func getPreparedStatement(reportEntry *ReportEntry, db *sql.DB) (*sql.Stmt, erro
 		return stmt, nil
 	}
 
-	stmt, err = db.Prepare(query)
+	stmt, err = dbMain.Prepare(query)
 	if err != nil {
 		return nil, err
 	}

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -162,7 +162,7 @@ func Startup() {
 		logger.Info("SQLite3 Database Version:%s  File:%s/%s  Limit:%d MB\n", dbVersion, dbFILEPATH, dbFILENAME, dbSizeLimit/oneMEGABYTE)
 	}
 
-	dbMain.SetMaxOpenConns(4)
+	dbMain.SetMaxOpenConns(1)
 	dbMain.SetMaxIdleConns(2)
 
 	createTables()

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -680,35 +680,16 @@ func createTables() {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_session_id_time_stamp ON sessions (session_id, time_stamp DESC)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_id_time_stamp ON sessions (session_id, time_stamp DESC)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_wan_routing ON sessions (wan_rule_chain, server_interface_type, time_stamp DESC)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_wan_interface_time_stamp ON sessions (wan_rule_chain, server_interface_type, time_stamp DESC)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_client_address ON sessions (session_id, time_stamp DESC, client_address)`)
-	if err != nil {
-		logger.Err("Failed to create index: %s\n", err.Error())
-	}
-
-	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_server_port ON sessions (session_id, time_stamp DESC, server_port)`)
-	if err != nil {
-		logger.Err("Failed to create index: %s\n", err.Error())
-	}
-
-	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_app_name ON sessions (session_id, time_stamp DESC, application_name)`)
-	if err != nil {
-		logger.Err("Failed to create index: %s\n", err.Error())
-	}
-
-	_, err = dbMain.Exec(`CREATE INDEX idx_sessions_app_proto ON sessions (session_id, time_stamp DESC, application_protochain)`)
-	if err != nil {
-		logger.Err("Failed to create index: %s\n", err.Error())
-	}
 	// FIXME add domain (SNI + dns_prediction + cert_prediction)
 	// We need a singular "domain" field that takes all the various domain determination methods into account and chooses the best one
 	// I think the preference order is:
@@ -810,37 +791,42 @@ func createTables() {
 		logger.Err("Failed to create table: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_interface_stats_time_stamp ON interface_stats (time_stamp DESC)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_time_stamp ON interface_stats (time_stamp DESC)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_ping_timeout ON interface_stats (interface_id, time_stamp DESC, ping_timeout)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_time_stamp ON interface_stats (interface_id, time_stamp DESC)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_rx_bytes ON interface_stats (interface_id, time_stamp DESC, rx_bytes)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_pt ON interface_stats (interface_id, time_stamp DESC, ping_timeout)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_jitter_1 ON interface_stats (interface_id, time_stamp DESC, jitter_1)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_rb ON interface_stats (interface_id, time_stamp DESC, rx_bytes)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_latency ON interface_stats (interface_id, time_stamp DESC, latency_1)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_jit ON interface_stats (interface_id, time_stamp DESC, jitter_1)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_active_latency ON interface_stats (interface_id, time_stamp DESC, active_latency_1)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_lat ON interface_stats (interface_id, time_stamp DESC, latency_1)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}
 
-	_, err = dbMain.Exec(`CREATE INDEX idx_passive_latency ON interface_stats (interface_id, time_stamp DESC, passive_latency_1)`)
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_al ON interface_stats (interface_id, time_stamp DESC, active_latency_1)`)
+	if err != nil {
+		logger.Err("Failed to create index: %s\n", err.Error())
+	}
+
+	_, err = dbMain.Exec(`CREATE INDEX idx_iface_stats_id_ts_pl ON interface_stats (interface_id, time_stamp DESC, passive_latency_1)`)
 	if err != nil {
 		logger.Err("Failed to create index: %s\n", err.Error())
 	}

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -982,6 +982,12 @@ func dbCleaner() {
 	}
 }
 
+// loadDbStats gets the page size, page count, free list size, and current DB size from the database
+// returns currentSize (int64) - The DB Size in bytes
+// returns pageSize (int64) - The current page size of each DB page
+// returns pageCount (int64) - The current number of pages in the database 
+// returns maxPageCount (int64) - The maximum number of pages the database can hold
+// returns freeCount (int64) - The number of free pages in the DB file
 func loadDbStats() (currentSize int64, pageSize int64, pageCount int64, maxPageCount int64, freeCount int64) {
 	var err error
 

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -573,7 +573,7 @@ func getRows(rows *sql.Rows, limit int) ([]map[string]interface{}, error) {
 	values := make([]interface{}, columnCount)
 	valuePtrs := make([]interface{}, columnCount)
 
-	for i := 0; rows.Next() && i < limit; i++ {
+	for i := 0; i < limit && rows.Next(); i++ {
 		for i := 0; i < columnCount; i++ {
 			valuePtrs[i] = &values[i]
 		}

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -268,7 +268,7 @@ func CreateQuery(reportEntryStr string) (*Query, error) {
 
 	// I believe this is here to cleanup stray queries that may be locking the database?
 	go func() {
-		time.Sleep(30 * time.Second)
+		time.Sleep(60 * time.Second)
 		cleanupQuery(q)
 	}()
 	return q, nil

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -904,7 +904,7 @@ func dbCleaner() {
 		// database is getting full so clean out some of the oldest data
 		logger.Info("Database starting trim operation\n")
 		trimPercent("sessions", .10)
-		trimPercent("session_stats", .25)
+		trimPercent("session_stats", .10)
 		trimPercent("interface_stats", .10)
 		//also run optimize
 		runSQL("PRAGMA optimize")

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -198,6 +198,10 @@ func customHook(conn *sqlite3.SQLiteConn) error {
 		logger.Warn("Error setting busy_timeout: %v\n", err)
 	}
 
+	// enable auto vaccuum = FULL
+	if _, err := conn.Exec("PRAGMA auto_vacuum = FULL", nil); err != nil {
+		logger.Warn("Error setting auto_vacuum: %v\n", err)
+	}
 	return nil
 }
 

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -69,6 +69,7 @@ type QuerySeriesOptions struct {
 type QueryEventsOptions struct {
 	OrderByColumn string `json:"orderByColumn"`
 	OrderAsc      bool   `json:"orderAsc"`
+	Limit         int    `json:"limit"`
 }
 
 // ReportCondition holds a SQL reporting condition (ie client = 1.2.3.4)

--- a/services/reports/reports.go
+++ b/services/reports/reports.go
@@ -162,7 +162,7 @@ func Startup() {
 		logger.Info("SQLite3 Database Version:%s  File:%s/%s  Limit:%d MB\n", dbVersion, dbFILEPATH, dbFILENAME, dbSizeLimit/oneMEGABYTE)
 	}
 
-	dbMain.SetMaxOpenConns(1)
+	dbMain.SetMaxOpenConns(4)
 	dbMain.SetMaxIdleConns(2)
 
 	createTables()

--- a/services/reports/sql.go
+++ b/services/reports/sql.go
@@ -93,8 +93,8 @@ func makeEventsSQLString(reportEntry *ReportEntry) (string, error) {
 
 	sqlStr += fmt.Sprintf(" ORDER BY %s %s", orderByColumn, order)
 
-	if reportEntry.QueryCategories.Limit != 0 {
-		sqlStr += fmt.Sprintf(" LIMIT %d", reportEntry.QueryCategories.Limit)
+	if reportEntry.QueryEvents.Limit != 0 {
+		sqlStr += fmt.Sprintf(" LIMIT %d", reportEntry.QueryEvents.Limit)
 	}
 
 	logger.Debug("Events SQL: %v\n", sqlStr)

--- a/services/reports/sql.go
+++ b/services/reports/sql.go
@@ -93,6 +93,10 @@ func makeEventsSQLString(reportEntry *ReportEntry) (string, error) {
 
 	sqlStr += fmt.Sprintf(" ORDER BY %s %s", orderByColumn, order)
 
+	if reportEntry.QueryCategories.Limit != 0 {
+		sqlStr += fmt.Sprintf(" LIMIT %d", reportEntry.QueryCategories.Limit)
+	}
+
 	logger.Debug("Events SQL: %v\n", sqlStr)
 	return sqlStr, nil
 }
@@ -138,14 +142,15 @@ func makeCategoriesSQLString(reportEntry *ReportEntry) (string, error) {
 		sqlStr += newStr
 	}
 	sqlStr += " GROUP BY " + reportEntry.QueryCategories.GroupColumn
+
+	// remove "0" values
+	sqlStr += " HAVING value > 0"
+
 	sqlStr += fmt.Sprintf(" ORDER BY %d %s", orderByColumn, order)
 
 	if reportEntry.QueryCategories.Limit != 0 {
 		sqlStr += fmt.Sprintf(" LIMIT %d", reportEntry.QueryCategories.Limit)
 	}
-
-	// remove "0" values
-	sqlStr = "SELECT " + reportEntry.QueryCategories.GroupColumn + ", value FROM ( " + sqlStr + " ) WHERE value > 0"
 
 	logger.Debug("Categories SQL: %v %v\n", sqlStr)
 	return sqlStr, nil

--- a/services/reports/sql.go
+++ b/services/reports/sql.go
@@ -244,7 +244,7 @@ func makeCategoriesSeriesSQLString(reportEntry *ReportEntry) (string, error) {
 	}
 	if len(columns) == 0 {
 		//return "", errors.New("No values for series")
-		return "SELECT null", nil
+		return "SELECT null WHERE null > ? AND NULL < ?;", nil
 	}
 	reportEntry.QuerySeries.Columns = columns
 


### PR DESCRIPTION
-Added LIMIT as an input to the create query APIs
-Enabled Auto_vacuum = FULL to assist with trimming the database size
-Added Prepared Statements logic to the Create Query APIs
-Bug fix for amount of items returned when LIMIT is specified
-Additional indexes to speed up our default reports
-Refactor the database trim logic, print DB size before and after, execute deletes within a single transaction instead of three separate transactions
-General refactoring on some of the SQL building logic (HAVING vs SELECT * FROM (SELECT), bug fix when no data is available for interface stats yet)