### PR TITLE
Mfw 859 geoip database update deux

### DIFF
--- a/plugins/geoip/geoip.go
+++ b/plugins/geoip/geoip.go
@@ -142,14 +142,14 @@ func PluginNfqueueHandler(mess dispatch.NfqueueMessage, ctid uint32, newSession 
 	// is still unknown we do the database lookup
 
 	if geoDatabaseReader != nil && srcAddr != nil && clientCountry == "XU" {
-		SrcRecord, err := geoDatabaseReader.City(srcAddr)
+		SrcRecord, err := geoDatabaseReader.Country(srcAddr)
 		if (err == nil) && (len(SrcRecord.Country.IsoCode) != 0) {
 			clientCountry = SrcRecord.Country.IsoCode
 		}
 	}
 
 	if geoDatabaseReader != nil && dstAddr != nil && serverCountry == "XU" {
-		DstRecord, err := geoDatabaseReader.City(dstAddr)
+		DstRecord, err := geoDatabaseReader.Country(dstAddr)
 		if (err == nil) && (len(DstRecord.Country.IsoCode) != 0) {
 			serverCountry = DstRecord.Country.IsoCode
 		}


### PR DESCRIPTION
I reworked the GeoIP database logic to handle the new tar.gz file we
now get from MaxMind. I also added a periodic task that will download
a new database when the local copy is more than 30 days old. I removed
some legacy cruft where we checked for different files in several
different locations. Now that we have the geoip-database package on
OpenWRT that puts the initial mmdb file in a know location, it makes
sense to always use that location, only falling back to /tmp as
a failsafe.
