### PR TITLE
Added a rest endpoint to retreive the wireguard public key

### DIFF
--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -115,6 +115,7 @@ func Startup() {
 	api.GET("/status/wwan/:device", statusWwan)
 	api.GET("/status/wifichannels/:device", statusWifiChannels)
 	api.GET("/status/wifimodelist/:device", statusWifiModelist)
+	api.GET("/status/wireguardPublicKey/:device", statusWireguardPublicKey)
 
 	api.GET("/logger/:source", loggerHandler)
 	api.GET("/debug", debugHandler)

--- a/services/restd/status.go
+++ b/services/restd/status.go
@@ -372,6 +372,19 @@ func statusWifiModelist(c *gin.Context) {
 	return
 }
 
+// statusWireguardPublicKey is the RESTD /api/status/wireguardPublicKey handler
+func statusWireguardPublicKey(c *gin.Context) {
+	device := c.Param("device")
+	result, err := exec.Command("/usr/bin/wg", "show", device, "public-key").CombinedOutput()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"publicKey": string(result)})
+	return
+}
+
 type dhcpInfo struct {
 	LeaseExpiration uint   `json:"leaseExpiration"`
 	MACAddress      string `json:"macAddress"`


### PR DESCRIPTION
MFW-494

The wireguard public key is not set in interface settings.
Given that it is retreived using a status call.