### PR TITLE
Mfw 945 netspace manager

### DIFF
--- a/cmd/packetd/packetd.go
+++ b/cmd/packetd/packetd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/untangle/packetd/services/dispatch"
 	"github.com/untangle/packetd/services/kernel"
 	"github.com/untangle/packetd/services/logger"
+	"github.com/untangle/packetd/services/netspace"
 	"github.com/untangle/packetd/services/overseer"
 	"github.com/untangle/packetd/services/predicttrafficsvc"
 	"github.com/untangle/packetd/services/reports"
@@ -285,6 +286,7 @@ func startServices() {
 	dict.Startup()
 	restd.Startup()
 	certcache.Startup()
+	netspace.Startup()
 	overseer.Startup()
 	certmanager.Startup()
 
@@ -301,6 +303,7 @@ func stopServices() {
 			predicttrafficsvc.Shutdown()
 		}
 		overseer.Shutdown()
+		netspace.Shutdown()
 		certmanager.Shutdown()
 		certcache.Shutdown()
 		restd.Shutdown()

--- a/services/logger/logger.go
+++ b/services/logger/logger.go
@@ -439,6 +439,7 @@ func initLoggerConfig() {
 	config["dispatch"] = "INFO"
 	config["kernel"] = "INFO"
 	config["logger"] = "INFO"
+	config["netspace"] = "INFO"
 	config["overseer"] = "INFO"
 	config["predicttrafficsvc"] = "INFO"
 	config["reports"] = "INFO"

--- a/services/netspace/netspace.go
+++ b/services/netspace/netspace.go
@@ -1,0 +1,182 @@
+package netspace
+
+import (
+	"container/list"
+	"net"
+	"sync"
+
+	"github.com/untangle/packetd/services/logger"
+)
+
+/*
+	Class for managing network address blocks that are in use across all
+	applications and services.
+*/
+
+// NetworkSpace stores details about a network address block
+type NetworkSpace struct {
+	OwnerName    string
+	OwnerPurpose string
+	Network      net.IPNet
+}
+
+var networkRegistry *list.List
+var networkMutex sync.RWMutex
+
+// Startup is called to handle service startup
+func Startup() {
+	logger.Debug("The netspace manager is starting\n")
+	networkRegistry = list.New()
+
+	// TODO - this is for testing and should be removed
+	RegisterNetworkCIDR("test", "test", "192.168.222.0/24")
+}
+
+// Shutdown is called to handle service shutdown
+func Shutdown() {
+	logger.Debug("The netspace manager is finished\n")
+}
+
+// RegisterNetworkParts is called to register a network address block reservation
+func RegisterNetworkParts(ownerName string, ownerPurpose string, networkAddress net.IP, networkSize int) {
+	var netobj net.IPNet
+	netobj.IP = networkAddress
+	// TODO - need to handle IPv4 and IPv6
+	netobj.Mask = net.CIDRMask(networkSize, 32)
+	RegisterNetworkNet(ownerName, ownerPurpose, netobj)
+}
+
+// RegisterNetworkCIDR is called to register a network address block reservation
+func RegisterNetworkCIDR(ownerName string, ownerPurpose string, networkText string) {
+	_, netobj, err := net.ParseCIDR(networkText)
+	if err != nil {
+		logger.Warn("Error %v registering CIDR: %s\n", err, networkText)
+		return
+	}
+
+	RegisterNetworkNet(ownerName, ownerPurpose, *netobj)
+}
+
+// RegisterNetworkNet is called to register a network address block reservation
+func RegisterNetworkNet(ownerName string, ownerPurpose string, networkInfo net.IPNet) {
+	space := new(NetworkSpace)
+	space.OwnerName = ownerName
+	space.OwnerPurpose = ownerPurpose
+	space.Network = networkInfo
+	networkMutex.Lock()
+	networkRegistry.PushBack(space)
+	networkMutex.Unlock()
+	logger.Debug("Added Netspace: %v\n", space)
+}
+
+// ClearOwnerRegistrationAll is called to clear all reservations for a specified owner
+func ClearOwnerRegistrationAll(ownerName string) {
+	var worker *NetworkSpace
+
+	networkMutex.Lock()
+
+	for item := networkRegistry.Front(); item != nil; item = item.Next() {
+		worker = item.Value.(*NetworkSpace)
+		if worker.OwnerName == ownerName {
+			networkRegistry.Remove(item)
+			logger.Debug("Removed Netspace: %v\n", worker)
+		}
+	}
+
+	networkMutex.Lock()
+}
+
+// ClearOwnerRegistrationPurpose is called to clear all reservations for a specified owner and purpose
+func ClearOwnerRegistrationPurpose(ownerName string, ownerPurpose string) {
+	var worker *NetworkSpace
+
+	networkMutex.Lock()
+
+	for item := networkRegistry.Front(); item != nil; item = item.Next() {
+		worker = item.Value.(*NetworkSpace)
+		if worker.OwnerName == ownerName && worker.OwnerPurpose == ownerPurpose {
+			networkRegistry.Remove(item)
+			logger.Debug("Removed Netspace: %v\n", worker)
+		}
+	}
+
+	networkMutex.Lock()
+}
+
+// IsNetworkAvailableParts checks to see if a a network address block is available
+func IsNetworkAvailableParts(ownerName string, networkAddress net.IP, networkSize int) *NetworkSpace {
+	var netobj net.IPNet
+	netobj.IP = networkAddress
+	// TODO - need to handle IPv4 and IPv6
+	netobj.Mask = net.CIDRMask(networkSize, 32)
+	return IsNetworkAvailableNet(ownerName, netobj)
+}
+
+// IsNetworkAvailableCIDR checks to see if a a network address block is available
+func IsNetworkAvailableCIDR(ownerName string, networkText string) *NetworkSpace {
+	_, netobj, err := net.ParseCIDR(networkText)
+	if err != nil {
+		logger.Warn("Error %v checking CIDR: %s\n", err, networkText)
+		return nil
+	}
+
+	return IsNetworkAvailableNet(ownerName, *netobj)
+}
+
+// IsNetworkAvailableNet checks to see if a a network address block is available
+func IsNetworkAvailableNet(ownerName string, networkInfo net.IPNet) *NetworkSpace {
+	var worker *NetworkSpace
+
+	networkMutex.RLock()
+	defer networkMutex.RUnlock()
+
+	for item := networkRegistry.Front(); item != nil; item = item.Next() {
+		worker = item.Value.(*NetworkSpace)
+		if worker.OwnerName != ownerName {
+			if checkForConflict(&networkInfo, &worker.Network) {
+				logger.Debug("Found conflict: %v %v\n", networkInfo, worker)
+				return worker
+			}
+		}
+	}
+
+	return nil
+}
+
+func checkForConflict(one *net.IPNet, two *net.IPNet) bool {
+
+	/*
+		TODO - THIS IS CURRENTLY BROKEN
+		https://play.golang.org/p/Kur5n2hfLg
+
+		test intersect(1.1.1.0/24,1.1.0.0/16)=false expected=true => FAIL
+		test intersect(1.1.0.0/16,1.1.1.0/24)=true expected=true => good
+		test intersect(1.1.1.0/24,1.1.1.0/25)=true expected=true => good
+		test intersect(1.1.1.0/25,1.1.1.0/24)=true expected=true => good
+		test intersect(1.1.1.0/24,1.2.0.0/16)=false expected=false => good
+		test intersect(1.2.0.0/16,1.1.1.0/24)=false expected=false => good
+	*/
+
+	for i := range one.IP {
+		if one.IP[i]&one.Mask[i] != two.IP[i]&two.Mask[i]&one.Mask[i] {
+			return false
+		}
+	}
+	return true
+}
+
+/*
+
+IPMaskedAddress getAvailableAddressSpace(IPVersion version, int hostId, int networkSize);
+
+InetAddress getFirstUsableAddress(InetAddress networkAddress, Integer networkSize);
+
+InetAddress getFirstUsableAddress(String networkText);
+
+public static enum IPVersion { IPv4, IPv6 };
+
+private IPMaskedAddress getRandomLocalIp6Address(Random rand, int CIDRSpace);
+
+private IPMaskedAddress getRandomLocalIp4Address(Random rand, int hostIdentifier, int CIDRSpace);
+
+*/

--- a/services/netspace/netspace.go
+++ b/services/netspace/netspace.go
@@ -102,7 +102,7 @@ func ClearOwnerRegistrationAll(ownerName string) {
 		}
 	}
 
-	networkMutex.Lock()
+	networkMutex.Unlock()
 }
 
 // ClearOwnerRegistrationPurpose is called to clear all reservations for a specified owner and purpose
@@ -121,7 +121,7 @@ func ClearOwnerRegistrationPurpose(ownerName string, ownerPurpose string) {
 		}
 	}
 
-	networkMutex.Lock()
+	networkMutex.Unlock()
 }
 
 // IsNetworkAvailableParts checks to see if a a network address block is available
@@ -239,6 +239,8 @@ func GetAvailableAddressSpace(ipVersion int, hostID int, networkSize int) *net.I
 		// got a network we havent tried yet so add to test map
 		testMap[randTxt] = true
 
+		networkMutex.RLock()
+
 		// see if the network conflicts with anything already registered
 		for item := networkRegistry.Front(); item != nil; item = item.Next() {
 			space := item.Value.(*NetworkSpace)
@@ -248,6 +250,8 @@ func GetAvailableAddressSpace(ipVersion int, hostID int, networkSize int) *net.I
 				break
 			}
 		}
+
+		networkMutex.RUnlock()
 
 		// if randNet is good we have an available address space to return
 		if randNet != nil {

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/untangle/packetd/services/dispatch"
 	"github.com/untangle/packetd/services/kernel"
 	"github.com/untangle/packetd/services/logger"
+	"github.com/untangle/packetd/services/netspace"
 	"github.com/untangle/packetd/services/overseer"
 	"github.com/untangle/packetd/services/reports"
 	"github.com/untangle/packetd/services/settings"
@@ -94,6 +95,8 @@ func Startup() {
 	api.POST("/warehouse/cleanup", warehouseCleanup)
 	api.GET("/warehouse/status", warehouseStatus)
 	api.POST("/control/traffic", trafficControl)
+
+	api.POST("/netspace/request", netspaceRequest)
 
 	api.GET("/status/sessions", statusSessions)
 	api.GET("/status/system", statusSystem)
@@ -823,4 +826,68 @@ func renewDhcp(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"success": true})
 	return
+}
+
+// called to request an unused network address block
+func netspaceRequest(c *gin.Context) {
+	var data map[string]string
+	var body []byte
+	var rawdata string
+	var ipVersion int
+	var hostID int
+	var networkSize int
+	var found bool
+	var err error
+
+	body, err = ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+
+	rawdata, found = data["ipVersion"]
+	if found != true {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "ipVersion not specified"})
+		return
+	}
+
+	ipVersion, err = strconv.Atoi(rawdata)
+	if err != nil {
+		ipVersion = 4
+	}
+
+	rawdata, found = data["hostID"]
+	if found != true {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "hostID not specified"})
+		return
+	}
+
+	hostID, err = strconv.Atoi(rawdata)
+	if err != nil {
+		hostID = 1
+	}
+
+	rawdata, found = data["networkSize"]
+	if found != true {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "networkSize not specified"})
+		return
+	}
+
+	networkSize, err = strconv.Atoi(rawdata)
+	if err != nil {
+		networkSize = 24
+	}
+
+	network := netspace.GetAvailableAddressSpace(ipVersion, hostID, networkSize)
+
+	c.JSON(http.StatusOK, gin.H{
+		"address": network.IP.String(),
+		"netmask": network.Mask.String(),
+	})
 }

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -885,6 +885,10 @@ func netspaceRequest(c *gin.Context) {
 	}
 
 	network := netspace.GetAvailableAddressSpace(ipVersion, hostID, networkSize)
+	if network == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unable to find an unused network"})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"address": network.IP.String(),


### PR DESCRIPTION
The netspace manager has been added to packetd. See MFW-945 for details on calling the new API function to retrieve an unused network address block.
