### PR TITLE
Fix netspace manager to limit available block size request

### DIFF
--- a/services/netspace/netspace.go
+++ b/services/netspace/netspace.go
@@ -213,7 +213,7 @@ func GetAvailableAddressSpace(ipVersion int, hostID int, networkSize int) *net.I
 	}
 
 	// validate the networkSize
-	if ipVersion == 4 && networkSize > 32 || networkSize < 8 {
+	if ipVersion == 4 && networkSize > 32 || networkSize < 24 {
 		logger.Warn("Invalid IPv4 networkSize %d passed to GetAvailableAddressSpace\n", networkSize)
 		networkSize = 24
 	}

--- a/services/restd/restd.go
+++ b/services/restd/restd.go
@@ -895,7 +895,7 @@ func netspaceRequest(c *gin.Context) {
 	cidr := fmt.Sprintf("%s/%d", addr, size)
 
 	c.JSON(http.StatusOK, gin.H{
-		"address": addr,
+		"network": addr,
 		"netsize": size,
 		"cidr":    cidr,
 	})


### PR DESCRIPTION
During an engineering review we determine that our goal with this function is to provide reasonable default blocks of address space that don't conflict with existing networks. To that end, I have limited the networkSize for requests to a value in the 24-32 range. Requests with a size outside that range will have the size adjusted to 24. I renamed the address field in response to network to prevent confusion since we are returning the network address of the space and not the address of a host within it. Example JSON replies:

{"cidr":"10.49.99.0/24","netsize":24,"network":"10.49.99.0"}
{"cidr":"172.18.216.128/25","netsize":25,"network":"172.18.216.128"}
