### PR TITLE
Mfw 1059 event logging rework

### DIFF
--- a/services/reports/events.go
+++ b/services/reports/events.go
@@ -1,0 +1,136 @@
+package reports
+
+/*
+These functions provide the low level framework for capturing session and
+interface stats in the system database. This data is used to display
+the dashboard and other session details in the management interface.
+
+The GetxxxColumnList functions return the list of columns in the corresponding
+table in the order they appear in the prepared INSERT statment. When logging these
+events to the database, the values MUST be appended to the values interface array
+in this order so the correct values are written to the corresponding columns.
+
+The GetxxxInsertQuery functions return a string generated using the GetxxxColumnList
+function that is used to create the prepared statement for inserting each event
+type in the database.
+*/
+
+// GetInterfaceStatsColumnList returns the columns in the interface_stats database table
+func GetInterfaceStatsColumnList() []string {
+	return []string{
+		"time_stamp",
+		"interface_id",
+		"device_name",
+		"is_wan",
+		"latency_1",
+		"latency_5",
+		"latency_15",
+		"latency_variance",
+		"passive_latency_1",
+		"passive_latency_5",
+		"passive_latency_15",
+		"passive_latency_variance",
+		"active_latency_1",
+		"active_latency_5",
+		"active_latency_15",
+		"active_latency_variance",
+		"jitter_1",
+		"jitter_5",
+		"jitter_15",
+		"jitter_variance",
+		"ping_timeout",
+		"ping_timeout_rate",
+		"rx_bytes",
+		"rx_bytes_rate",
+		"rx_packets",
+		"rx_packets_rate",
+		"rx_errs",
+		"rx_errs_rate",
+		"rx_drop",
+		"rx_drop_rate",
+		"rx_fifo",
+		"rx_fifo_rate",
+		"rx_frame",
+		"rx_frame_rate",
+		"rx_compressed",
+		"rx_compressed_rate",
+		"rx_multicast",
+		"rx_multicast_rate",
+		"tx_bytes",
+		"tx_bytes_rate",
+		"tx_packets",
+		"tx_packets_rate",
+		"tx_errs",
+		"tx_errs_rate",
+		"tx_drop",
+		"tx_drop_rate",
+		"tx_fifo",
+		"tx_fifo_rate",
+		"tx_colls",
+		"tx_colls_rate",
+		"tx_carrier",
+		"tx_carrier_rate",
+		"tx_compressed",
+		"tx_compressed_rate",
+	}
+}
+
+// GetInterfaceStatsInsertQuery generates the SQL for creating the prepared INSERT statment for the interface_stats table
+func GetInterfaceStatsInsertQuery() string {
+	colList := GetInterfaceStatsColumnList()
+	sqlStr := "INSERT INTO interface_stats ("
+	valStr := "("
+
+	for x := 0; x < len(colList); x++ {
+		if x != 0 {
+			sqlStr += ","
+			valStr += ","
+		}
+		sqlStr += colList[x]
+		valStr += "?"
+	}
+
+	sqlStr += ")"
+	valStr += ")"
+	return (sqlStr + " VALUES " + valStr)
+}
+
+// GetSessionStatsColumnList returns the list of columns in the session_stats table
+func GetSessionStatsColumnList() []string {
+	return []string{
+		"time_stamp",
+		"session_id",
+		"bytes",
+		"byte_rate",
+		"client_bytes",
+		"client_byte_rate",
+		"server_bytes",
+		"server_byte_rate",
+		"packets",
+		"packet_rate",
+		"client_packets",
+		"client_packet_rate",
+		"server_packets",
+		"server_packet_rate",
+	}
+}
+
+// GetSessionStatsInsertQuery generates the SQL for creating the prepared INSERT statement for the session_stats table
+func GetSessionStatsInsertQuery() string {
+	colList := GetSessionStatsColumnList()
+	sqlStr := "INSERT INTO session_stats ("
+	valStr := "("
+
+	for x := 0; x < len(colList); x++ {
+		if x != 0 {
+			sqlStr += ","
+			valStr += ","
+		}
+		sqlStr += colList[x]
+		valStr += "?"
+	}
+
+	sqlStr += ")"
+	valStr += ")"
+	return (sqlStr + " VALUES " + valStr)
+}


### PR DESCRIPTION
I improved the efficiency of logging to interface_stats and session_stats using prepared statements. I used a quick and dirty approach to compare performance. I compared the speed of inserting 100,000 via a direct sql.Exec INSERT call vs. doing the same with a prepared sql.Stmt INSERT call, and the speed difference was significant:

38 seconds using sql.Exec INSERT
15 seconds using the prepared INSERT statement

I don't think we'll get much benefit on the interface_stats, since it only handles one insert per WAN interface every 10 seconds. However, the session_stats table sees a lot more traffic, as we log incremental rx/tx byte counts for every session in what appears to be near real time on conntrack UPDATE event processing, so the gains here could be huge.

At one point, I had similar logic working on the sessions table, but started running into all kinds of data race errors, likely due to conflicts between multiple goroutines directly accessing data in the Session object. I suspect using more locking to address those problems would actually reduce performance/throughput. However, we already have transaction batching for the event handler, and now that the interface and sessions stats have been moved to their own queue, that mechanism may work even better as it will only be dealing with INSERT and UPDATE statements on the sessions table.