### PR TITLE
Add address conflict check function

### DIFF
--- a/services/netspace/netspace.go
+++ b/services/netspace/netspace.go
@@ -170,7 +170,7 @@ func IsNetworkAvailableNet(ownerName string, networkInfo net.IPNet) *NetworkSpac
 
 	for item := networkRegistry.Front(); item != nil; item = item.Next() {
 		space = item.Value.(*NetworkSpace)
-		if space.OwnerName != ownerName {
+		if len(ownerName) == 0 || space.OwnerName != ownerName {
 			if checkForConflict(&networkInfo, &space.Network) {
 				logger.Debug("Found conflict: %v %v\n", networkInfo, space)
 				return space
@@ -178,6 +178,7 @@ func IsNetworkAvailableNet(ownerName string, networkInfo net.IPNet) *NetworkSpac
 		}
 	}
 
+	logger.Debug("Available network: %v\n", networkInfo)
 	return nil
 }
 


### PR DESCRIPTION
Added a check function that is called by the user interface to detect address conflicts with registered netspace entries. Fixed the available network check function to ignore ownerName if length is zero. Added an API endpoint for calling the new check function.
