### PR TITLE
travis: build the docker image each time instead of relying on what's…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - mv "$TRAVIS_BUILD_DIR" "${DIR}/packetd"
 - cd "${DIR}/packetd"
 script:
-- docker-compose -f build/docker-compose.build.yml up --build $TARGET || travis_terminate 1
+- docker-compose -f build/docker-compose.build.yml up --build ${TARGET}-local || travis_terminate 1
 - test -f ./cmd/packetd/packetd && file ./cmd/packetd/packetd | $TEST
 notifications:
   email: false


### PR DESCRIPTION
… on hub.docker.com

We're willing to take the performance penalty in exchange for greater
flexibility and a lesser amount of surprise for developers: "I updated
the build Dockerfile, and the CI pipeline should pick that up
automatically without a push to hub.docker.com".