### PR TITLE
MFW-1435 passlist is not loaded.

### DIFF
--- a/plugins/threatprevention/threatprevention.go
+++ b/plugins/threatprevention/threatprevention.go
@@ -33,10 +33,10 @@ type contextKey struct {
 }
 
 type tpSettingType struct {
-	Enabled     bool     `json: "enabled"`
-	Sensitivity int      `json: "sensitivity"`
-	Redirect    bool     `json: "redirect`
-	PassList    []string `json: "passList"`
+	Enabled     bool          `json: "enabled"`
+	Sensitivity int           `json: "sensitivity"`
+	Redirect    bool          `json: "redirect`
+	PassList    []interface{} `json: "passList"`
 }
 
 var tpSettings tpSettingType
@@ -126,8 +126,8 @@ func createSettings(m map[string]interface{}) {
 				tpSettings.Sensitivity = DEFAULT_SENSITIVITY
 			}
 		}
-		if m["passlist"] != nil {
-			tpSettings.PassList = m["passList"].([]string)
+		if m["passList"] != nil {
+			tpSettings.PassList = m["passList"].([]interface{})
 		}
 	}
 }
@@ -140,8 +140,9 @@ func syncCallbackHandler() {
 
 	logger.Debug("tpSettings are (enabled, level, redirect, passList) %v\n", tpSettings)
 	for _, entry := range tpSettings.PassList {
-		logger.Debug("Inserting CIDR into ignore list: %s\n", entry)
-		_, pass, _ := net.ParseCIDR(entry)
+		p := entry.(map[string]interface{})
+		logger.Debug("Inserting CIDR into ignore list: %s\n", p["host"])
+		_, pass, _ := net.ParseCIDR(p["host"].(string))
 		ignoreIPBlocks = append(ignoreIPBlocks, pass)
 	}
 


### PR DESCRIPTION
passList was misspelled "passlist" code never executed.
Additional changes to parse out the host in the passList entry.

A passList entry has the structure.
 { "description": "Google dns","host": "8.8.8.8/32" }
  
